### PR TITLE
fix: filter out env-help from listed scripts

### DIFF
--- a/env-help.nix
+++ b/env-help.nix
@@ -12,12 +12,13 @@ with lib; {
   };
   config = mkIf config.env-help.enable {
     scripts."env-help" = {
-      description = "A help message for development environments.";
+      description = "Lists available scripts and their descriptions.";
       # TODO: Make it pretty
-      # TODO: Filter out env-help from the listed scripts
-      exec = ''
+      exec = let
+        scripts = builtins.removeAttrs config.scripts ["env-help"];
+      in ''
         ${pkgs.gnused}/bin/sed -e 's| |••|g' -e 's|=| |' <<EOF | ${pkgs.util-linuxMinimal}/bin/column -t | ${pkgs.gnused}/bin/sed -e 's|^|> |' -e 's|••| |g'
-        ${generators.toKeyValue {} (mapAttrs (_name: value: value.description) config.scripts)}
+        ${generators.toKeyValue {} (mapAttrs (_name: value: value.description) scripts)}
         EOF
       '';
     };


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change filters env-help out from the list of scripts

# Testing
<!--
How did you test your changes?
-->
Ran env-help locally

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None